### PR TITLE
fix: chunk name mismatch

### DIFF
--- a/src/chapter04/my-project/builder-webpack/lib/webpack.prod.js
+++ b/src/chapter04/my-project/builder-webpack/lib/webpack.prod.js
@@ -32,7 +32,7 @@ const prodConfig = {
       minSize: 0,
       cacheGroups: {
         commons: {
-          name: 'commons',
+          name: 'vendors',
           chunks: 'all',
           minChunks: 2,
         },

--- a/src/chapter05/my-project/builder-webpack/lib/webpack.prod.js
+++ b/src/chapter05/my-project/builder-webpack/lib/webpack.prod.js
@@ -32,7 +32,7 @@ const prodConfig = {
       minSize: 0,
       cacheGroups: {
         commons: {
-          name: 'commons',
+          name: 'vendors',
           chunks: 'all',
           minChunks: 2,
         },


### PR DESCRIPTION
splitChunks 名称和 HtmlWebpackPlugin 中的名称不匹配